### PR TITLE
Add cmd line arg for input for video module.

### DIFF
--- a/python-project/mortar/video.py
+++ b/python-project/mortar/video.py
@@ -68,7 +68,7 @@ def extract_frames() -> None:
 
     mkv_files = list(filter(lambda x: x.suffix == '.mkv', files))
 
-    for file in mkv_files[0:1]:
+    for file in mkv_files:
         parent = file.parent
         out_dir = Path(parent, 'png')
         out_template = Path(out_dir, f'{file.stem}-%02d.png')


### PR DESCRIPTION
Gave argparse a shot! Managed to test all cases for the video module:

- `--input` arg provided that was different from `'.'` and `config.data`
- No arg provided, `config.data` exists.
- No arg provided, `config.data` does not exist.