### PR TITLE
Typing updates

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -10,6 +10,7 @@ def lint(session):
 
 @nox.session(tags=['all'])
 def typing(session):
+    session.run('basedpyright', external=True)
     session.run('mypy', external=True)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ disallow_incomplete_defs = false
 disallow_untyped_defs = false
 disable_error_code = ["union-attr"]
 
+[tool.pylsp-mypy]
+enabled = false
+
 [tool.setuptools.package-data]
 "mortar.examples.data" = ["*"]
 "mortar.resources.fonts" = ["*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ include_trailing_comma = true
 split_on_trailing_comma = true
 
 [tool.mypy]
-explicit_package_bases = true
+cache_fine_grained = true
 packages = [ "mortar", "tests" ]
 exclude = "^src/mortar/examples"
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,11 @@ branch = true
 parallel = true
 source = [ "src" ]
 
+[tool.isort]
+multi_line_output=3
+include_trailing_comma = true
+split_on_trailing_comma = true
+
 [tool.mypy]
 explicit_package_bases = true
 packages = [ "mortar", "tests" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,17 @@ split_on_trailing_comma = true
 [tool.mypy]
 cache_fine_grained = true
 packages = [ "mortar", "tests" ]
-exclude = "^src/mortar/examples"
 strict = true
+
+[[tool.mypy.overrides]]
+module = [
+    "mortar.examples.*",
+]
+strict = false
+disallow_untyped_calls = false
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
+disable_error_code = ["union-attr"]
 
 [tool.setuptools.package-data]
 "mortar.examples.data" = ["*"]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,35 @@
+{
+  "include": [
+    "src",
+    "tests"
+  ],
+
+  "exclude": [
+  ],
+
+  "typeCheckingMode": "recommended",
+
+  "reportAny": true,
+
+  "executionEnvironments": [
+      {
+        "root": "src/mortar/examples",
+        "reportAny": false,
+        "reportArgumentType": false,
+        "reportUnusedCallResult": false,
+        "reportMissingParameterType": false,
+        "reportOptionalMemberAccess": false,
+        "reportUnannotatedClassAttribute": false,
+        "reportUnknownArgumentType": false,
+        "reportUnknownMemberType": false,
+        "reportUnknownParameterType": false,
+        "reportUnknownVariableType": false,
+      },
+      {
+        "root": "src"
+      }
+  ],
+
+  "pythonVersion": "3.12",
+  "pythonPlatform": "Linux",
+}

--- a/src/mortar/__init__.py
+++ b/src/mortar/__init__.py
@@ -7,4 +7,6 @@ import os
 __pdoc__ = {'examples': False}
 
 if os.name != 'posix':
-    raise Exception('This package is only supported under WSL.')
+    raise Exception(  # pyright: ignore[reportUnreachable]
+        'This package is only supported under WSL.'
+    )

--- a/src/mortar/examples/image/crop.py
+++ b/src/mortar/examples/image/crop.py
@@ -4,8 +4,17 @@ size = (1024, 1024)
 
 image = Image.effect_mandelbrot(size, (-1.5, -1, 0.5, 1), 100)
 
-crop = Crop((size[0] / 4, size[1] / 4, size[0] / 2, size[1] * 0.75))
+crop = Crop(
+    (
+        int(size[0] * 0.25),
+        int(size[1] * 0.25),
+        int(size[0] * 0.5),
+        int(size[1] * 0.75)
+    )
+)
 
 output = crop.run(image)
+
+assert isinstance(output, Image)
 
 output.show()

--- a/src/mortar/font.py
+++ b/src/mortar/font.py
@@ -1,10 +1,11 @@
 """
 This module provides font management.
 """
-
-from importlib import resources
+from os.path import isfile
 
 import PIL.Image
+from mktech.error import Err, Ok
+from mktech.resources import resource_path
 from PIL import ImageDraw, ImageFont
 from PIL.ImageFont import FreeTypeFont
 
@@ -17,14 +18,16 @@ def load(path: str, size: int) -> Font:
     error if the file does not exist.
     """
 
-    font_resources = resources.files('mortar.resources.fonts')
+    match resource_path('mortar.resources.fonts', path):
+        case Err(e):
+            raise e
+        case Ok(font_path):
+            if not isfile(font_path):
+                raise FileNotFoundError(f"Could not load font {path}.")
 
-    font = ImageFont.truetype(str(font_resources.joinpath(path)), size=size)
+            result = ImageFont.truetype(str(font_path), size=size)
 
-    if font is None:
-        raise FileNotFoundError(f"Could not load font {path}.")
-
-    return font
+    return result
 
 
 def text_size(text: str, font: Font) -> tuple[float, float]:

--- a/src/mortar/image/__init__.py
+++ b/src/mortar/image/__init__.py
@@ -11,4 +11,4 @@ from .viewer import Viewer
 
 __all__ = ['Image', 'create_text', 'Detector']
 
-ImageShow.register(Viewer(), 0)
+ImageShow.register(Viewer(), 0)  # pyright: ignore[reportUnknownMemberType]

--- a/src/mortar/image/detector.py
+++ b/src/mortar/image/detector.py
@@ -36,7 +36,7 @@ class Detector:
         contours, _ = cv2.findContours(
             thresh, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
 
-        rects = []
+        rects: list[tuple[int, int, int, int]] = []
 
         for cnt in contours:
             # Compute approximate contour vertex points

--- a/src/mortar/image/detector.py
+++ b/src/mortar/image/detector.py
@@ -2,9 +2,13 @@ import os
 from typing import Callable
 
 import cv2
+from cv2.typing import MatLike
 
 
 class Detector:
+    def __init__(self) -> None:
+        self.img: MatLike | None = None
+
     def detect_rects(
         self,
         img_path: str,
@@ -72,6 +76,9 @@ def main() -> None:
     )
 
     print(rects)
+
+    assert detector.img is not None
+
     cv2.imshow("Shapes", detector.img)
     _ = cv2.waitKey(0)
     cv2.destroyAllWindows()

--- a/src/mortar/image/detector.py
+++ b/src/mortar/image/detector.py
@@ -62,7 +62,7 @@ class Detector:
 def main() -> None:
     detector = Detector()
 
-    def my_condition(x: int, y: int, w: int, h: int) -> bool:
+    def my_condition(_x: int, _y: int, _w: int, h: int) -> bool:
         return h > 200
 
     rects = detector.detect_rects(
@@ -73,7 +73,7 @@ def main() -> None:
 
     print(rects)
     cv2.imshow("Shapes", detector.img)
-    cv2.waitKey(0)
+    _ = cv2.waitKey(0)
     cv2.destroyAllWindows()
 
 

--- a/src/mortar/image/image.py
+++ b/src/mortar/image/image.py
@@ -3,7 +3,7 @@ This module provides an Image class to be used for reading, writing, and
 manipulating images.
 """
 
-from typing import Any
+from typing import Any, override
 
 import PIL.Image
 from PIL import ImageChops
@@ -161,6 +161,7 @@ class Image:
 
         return instance
 
+    @override
     def __repr__(self) -> str:
         return (
             f'<{self.__class__.__module__} {self.__class__.__name__}'

--- a/src/mortar/image/image.py
+++ b/src/mortar/image/image.py
@@ -1,3 +1,4 @@
+# pyright: reportAny=false,reportExplicitAny=false
 # pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
 """
 This module provides an Image class to be used for reading, writing, and

--- a/src/mortar/image/image.py
+++ b/src/mortar/image/image.py
@@ -14,7 +14,6 @@ class Image:
     This class represents an image object. It's a convenience wrapper around
     the pillow library's Image class.
     """
-
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
@@ -163,6 +162,8 @@ class Image:
         return instance
 
     def __repr__(self) -> str:
-        return (f'<{self.__class__.__module__} {self.__class__.__name__}'
-                f' mode={self.pil_image.mode} size={self.pil_image.size}'
-                f' at 0x{id(self):X}>')
+        return (
+            f'<{self.__class__.__module__} {self.__class__.__name__}'
+            f' mode={self.pil_image.mode} size={self.pil_image.size}'
+            f' at 0x{id(self):X}>'
+        )

--- a/src/mortar/image/image.py
+++ b/src/mortar/image/image.py
@@ -1,3 +1,4 @@
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
 """
 This module provides an Image class to be used for reading, writing, and
 manipulating images.

--- a/src/mortar/image/image.py
+++ b/src/mortar/image/image.py
@@ -17,7 +17,7 @@ class Image:
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-        self.pil_image = PIL.Image.Image()
+        self.pil_image: PIL.Image.Image = PIL.Image.Image()
         " The instance of PIL.Image.Image wrapped by the Image object. "
 
     def convert(self, *args: Any, **kwargs: Any) -> 'Image':

--- a/src/mortar/image/text.py
+++ b/src/mortar/image/text.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 import PIL.Image
 from PIL import ImageDraw
@@ -10,7 +10,7 @@ from mortar.image.image import Image
 def create_text(
     text: str,
     font: Font,
-    fill_color: Optional[str] = None,
+    fill_color: str | None = None,
     margin: tuple[int, int] = (0, 0),
     *image_args: Any,
     **image_kwargs: Any

--- a/src/mortar/image/text.py
+++ b/src/mortar/image/text.py
@@ -4,7 +4,7 @@ import PIL.Image
 from PIL import ImageDraw
 
 from mortar.font import Font, text_size
-from mortar.image import Image
+from mortar.image.image import Image
 
 
 def create_text(

--- a/src/mortar/image/text.py
+++ b/src/mortar/image/text.py
@@ -1,9 +1,9 @@
 from typing import Any, Optional
 
 import PIL.Image
-from mortar.font import Font, text_size
 from PIL import ImageDraw
 
+from mortar.font import Font, text_size
 from mortar.image import Image
 
 

--- a/src/mortar/image/text.py
+++ b/src/mortar/image/text.py
@@ -12,8 +12,8 @@ def create_text(
     font: Font,
     fill_color: str | None = None,
     margin: tuple[int, int] = (0, 0),
-    *image_args: Any,
-    **image_kwargs: Any
+    *image_args: Any,  # pyright: ignore[reportAny,reportExplicitAny]
+    **image_kwargs: Any  # pyright: ignore[reportAny,reportExplicitAny]
 ) -> Image:
     """
     Draw a text string onto a new Image and return it. A Font object is
@@ -30,7 +30,12 @@ def create_text(
         round(text_size_[1]) + margin[1] * 2,
     )
 
-    image = PIL.Image.new('RGB', image_size, *image_args, **image_kwargs)
+    image = PIL.Image.new(
+        'RGB',
+        image_size,
+        *image_args,  # pyright: ignore[reportAny]
+        **image_kwargs,
+    )
 
     draw = ImageDraw.Draw(image)
 

--- a/src/mortar/image/text.py
+++ b/src/mortar/image/text.py
@@ -34,6 +34,8 @@ def create_text(
 
     draw = ImageDraw.Draw(image)
 
-    draw.text(margin, text, fill=fill_color, font=font)
+    draw.text(  # pyright: ignore[reportUnknownMemberType]
+        margin, text, fill=fill_color, font=font
+    )
 
     return Image.from_pil_image(image)

--- a/src/mortar/image/viewer.py
+++ b/src/mortar/image/viewer.py
@@ -23,7 +23,7 @@ class Viewer:
     Default image viewer for systems that don't have the existing PIL defaults
     available.
     """
-    def show(self, image: PILImage, **options: Any) -> bool:
+    def show(self, image: PILImage, **_options: Any) -> bool:
         """
         Implements PIL.ImageShow.show for the viewer.
 

--- a/src/mortar/image/viewer.py
+++ b/src/mortar/image/viewer.py
@@ -8,7 +8,6 @@ the path to the default image viewer.
 import os
 import subprocess
 from tempfile import NamedTemporaryFile
-from typing import Any
 
 from PIL.Image import Image as PILImage
 
@@ -23,7 +22,7 @@ class Viewer:
     Default image viewer for systems that don't have the existing PIL defaults
     available.
     """
-    def show(self, image: PILImage, **_options: Any) -> bool:
+    def show(self, image: PILImage, **_options: object) -> bool:
         """
         Implements PIL.ImageShow.show for the viewer.
 

--- a/src/mortar/path.py
+++ b/src/mortar/path.py
@@ -13,8 +13,7 @@ def win_from_wsl(path: str) -> PurePath:
 
     if not path.startswith('/mnt'):
         raise Exception(
-            'path is expected to be an absolute path on a WSL'
-            ' installation'
+            'path is expected to be an absolute path on a WSL installation'
         )
 
     parts = path.split('/')

--- a/src/mortar/pipeline/__init__.py
+++ b/src/mortar/pipeline/__init__.py
@@ -51,7 +51,7 @@ class Pipeline:
     result of the pipeline.
     """
     def __init__(self) -> None:
-        self._name = 'Pipeline'
+        self._name: str = 'Pipeline'
 
         self.stages: list[Filter] = []
         " The list of stages through which input is processed. "
@@ -134,9 +134,9 @@ class Output:
         The result of a Pipeline stage.
         """
         def __init__(self, data: Any, info: list[str] | None = None) -> None:
-            self.data = data
+            self.data: Any = data
             " The output of the corresponding Pipeline stage Filter. "
-            self.info = [] if info is None else info
+            self.info: list[str] = [] if info is None else info
             " Text information describing the output of the stage. "
 
         @override
@@ -146,19 +146,21 @@ class Output:
                 f' text={self.info} data={self.data} at 0x{id(self):X}>'
             )
 
-    _bg_color = 'rgb(25, 25, 25)'
-    _text_color = 'rgb(200, 200, 200)'
-    _margin = 10
-    _border_width = 5
+    _bg_color: str = 'rgb(25, 25, 25)'
+    _text_color: str = 'rgb(200, 200, 200)'
+    _margin: int = 10
+    _border_width: int = 5
 
     def __init__(self, pipeline: Pipeline) -> None:
-        self.pipeline = pipeline
+        self.pipeline: Pipeline = pipeline
         " The pipeline used to create this Output. "
+
         self.stages: list[Output.Stage] = []
         (
             " The list of output stages corresponding to the pipeline Filter "
             " stages. "
         )
+
         self._frames: list[Image] = []
 
     def add(self, stage: Image | str, text: list[str] | None = None) -> None:

--- a/src/mortar/pipeline/__init__.py
+++ b/src/mortar/pipeline/__init__.py
@@ -131,10 +131,10 @@ class Output:
         """
         The result of a Pipeline stage.
         """
-        def __init__(self, data: Any, info: list[str] = []) -> None:
+        def __init__(self, data: Any, info: list[str] | None = None) -> None:
             self.data = data
             " The output of the corresponding Pipeline stage Filter. "
-            self.info = info
+            self.info = [] if info is None else info
             " Text information describing the output of the stage. "
 
         def __repr__(self) -> str:
@@ -158,10 +158,12 @@ class Output:
         )
         self._frames: list[Image] = []
 
-    def add(self, stage: Image | str, text: list[str] = []) -> None:
+    def add(self, stage: Image | str, text: list[str] | None = None) -> None:
         """
         Add a stage to the Output stages.
         """
+
+        text = [] if text is None else text
 
         self.stages.append(Output.Stage(stage, text))
 

--- a/src/mortar/pipeline/__init__.py
+++ b/src/mortar/pipeline/__init__.py
@@ -217,7 +217,7 @@ class Output:
 
         draw = ImageDraw.Draw(canvas.pil_image)
 
-        draw.text(
+        draw.text(  # pyright: ignore[reportUnknownMemberType]
             (self._margin, y),
             self.pipeline.name,
             fill=self._text_color,
@@ -276,7 +276,7 @@ class Output:
 
             draw = ImageDraw.Draw(image.pil_image)
 
-            draw.text(
+            draw.text(  # pyright: ignore[reportUnknownMemberType]
                 (0, 0),
                 info,
                 fill=self._text_color,

--- a/src/mortar/pipeline/__init__.py
+++ b/src/mortar/pipeline/__init__.py
@@ -8,10 +8,10 @@ from functools import reduce
 from typing import Any
 
 from mktech.path import Path, PathInput
-from mortar.font import text_size
 from PIL import ImageDraw
 
 from mortar import font
+from mortar.font import text_size
 from mortar.image import Image, create_text
 
 from .filter import OCR, Crop, Filter, Gray, Invert, Threshold

--- a/src/mortar/pipeline/__init__.py
+++ b/src/mortar/pipeline/__init__.py
@@ -5,7 +5,7 @@ This package provides the image processing pipeline facility.
 import copy
 import operator
 from functools import reduce
-from typing import Any
+from typing import Any, override
 
 from mktech.path import Path, PathInput
 from PIL import ImageDraw
@@ -105,6 +105,7 @@ class Pipeline:
         """ Create and return a deep copy of the pipeline. """
         return copy.deepcopy(self)
 
+    @override
     def __eq__(self: object, other: object) -> bool:
         result = True
 
@@ -115,6 +116,7 @@ class Pipeline:
 
         return result
 
+    @override
     def __repr__(self) -> str:
         return (
             f'<{self.__class__.__module__} {self.__class__.__name__}'
@@ -137,6 +139,7 @@ class Output:
             self.info = [] if info is None else info
             " Text information describing the output of the stage. "
 
+        @override
         def __repr__(self) -> str:
             return (
                 f'<{self.__class__.__module__} {self.__class__.__name__}'
@@ -290,12 +293,14 @@ class Output:
 
             self._frames.append(image)
 
+    @override
     def __repr__(self) -> str:
         return (
             f'<{self.__class__.__module__} {self.__class__.__name__}'
             f' stages={self.stages} at 0x{id(self):X}>'
         )
 
+    @override
     def __str__(self) -> str:
         lines = ['Stages:']
 

--- a/src/mortar/pipeline/__init__.py
+++ b/src/mortar/pipeline/__init__.py
@@ -185,7 +185,7 @@ class Output:
                 file_path = Path(path, f'{idx}.txt')
 
                 with open(file_path, 'w') as file:
-                    file.write(it.data)
+                    _ = file.write(it.data)
             else:
                 raise TypeError()
 

--- a/src/mortar/pipeline/__init__.py
+++ b/src/mortar/pipeline/__init__.py
@@ -82,7 +82,7 @@ class Pipeline:
 
         filter_input: Any = input
 
-        for idx, it in enumerate(self.stages):
+        for _, it in enumerate(self.stages):
             filter_output = it.run(filter_input)
 
             output.add(filter_output, [it.info(), _image_info(filter_input)])

--- a/src/mortar/pipeline/filter.py
+++ b/src/mortar/pipeline/filter.py
@@ -48,10 +48,10 @@ class Filter:
         self_attrs = []
         other_attrs = []
 
-        for attr, value in self.__dict__.items():
+        for attr, _ in self.__dict__.items():
             self_attrs.append(attr)
 
-        for attr, value in other.__dict__.items():
+        for attr, _ in other.__dict__.items():
             other_attrs.append(attr)
 
         self_attrs.sort()

--- a/src/mortar/pipeline/filter.py
+++ b/src/mortar/pipeline/filter.py
@@ -183,6 +183,8 @@ class Threshold(Filter):
         maxval: float = 255,
         invert: bool = False
     ) -> None:
+        super().__init__()
+
         self.threshval = threshval
         self.maxval = maxval
         self.invert = invert

--- a/src/mortar/pipeline/filter.py
+++ b/src/mortar/pipeline/filter.py
@@ -7,7 +7,7 @@ processed output.
 
 import os
 from copy import copy
-from typing import Any, Optional
+from typing import Any, Optional, override
 
 import cv2 as cv
 import numpy as np
@@ -43,6 +43,7 @@ class Filter:
 
         return None
 
+    @override
     def __eq__(self: object, other: object) -> bool:
         self_attrs = []
         other_attrs = []
@@ -87,9 +88,11 @@ class Crop(Filter):
 
         self._coords = coords
 
+    @override
     def info(self) -> str:
         return f'{self.name} box={self._coords}'
 
+    @override
     def run(self, input: Image) -> Optional[Image]:
         super().run(input)
 
@@ -100,6 +103,7 @@ class Crop(Filter):
 
         return result
 
+    @override
     def __repr__(self) -> str:
         return (
             f'<{self.__class__.__module__} {self.__class__.__name__}'
@@ -113,6 +117,7 @@ class Gray(Filter):
     name = 'Gray'
     _input_type = Image
 
+    @override
     def run(self, input: Image) -> Optional[Image]:
         super().run(input)
 
@@ -130,6 +135,7 @@ class Invert(Filter):
     name = 'Invert'
     _input_type = Image
 
+    @override
     def run(self, input: Image) -> Optional[Image]:
         super().run(input)
 
@@ -147,6 +153,7 @@ class OCR(Filter):
     name = 'OCR'
     _input_type = Image
 
+    @override
     def run(self, input: Image) -> Optional[str]:
         """
         Perform OCR on an image and return the result.
@@ -189,6 +196,7 @@ class Threshold(Filter):
         self.maxval = maxval
         self.invert = invert
 
+    @override
     def run(self, input: Image) -> Optional[Image]:
         super().run(input)
 

--- a/src/mortar/pipeline/filter.py
+++ b/src/mortar/pipeline/filter.py
@@ -7,7 +7,7 @@ processed output.
 
 import os
 from copy import copy
-from typing import Any, Optional, override
+from typing import Any, override
 
 import cv2 as cv
 import numpy as np
@@ -93,7 +93,7 @@ class Crop(Filter):
         return f'{self.name} box={self._coords}'
 
     @override
-    def run(self, input: Image) -> Optional[Image]:
+    def run(self, input: Image) -> Image | None:
         super().run(input)
 
         if self._input is None:
@@ -118,7 +118,7 @@ class Gray(Filter):
     _input_type = Image
 
     @override
-    def run(self, input: Image) -> Optional[Image]:
+    def run(self, input: Image) -> Image | None:
         super().run(input)
 
         if self._input is None:
@@ -136,7 +136,7 @@ class Invert(Filter):
     _input_type = Image
 
     @override
-    def run(self, input: Image) -> Optional[Image]:
+    def run(self, input: Image) -> Image | None:
         super().run(input)
 
         if self._input is None:
@@ -154,7 +154,7 @@ class OCR(Filter):
     _input_type = Image
 
     @override
-    def run(self, input: Image) -> Optional[str]:
+    def run(self, input: Image) -> str | None:
         """
         Perform OCR on an image and return the result.
         """
@@ -197,7 +197,7 @@ class Threshold(Filter):
         self.invert = invert
 
     @override
-    def run(self, input: Image) -> Optional[Image]:
+    def run(self, input: Image) -> Image | None:
         super().run(input)
 
         if self._input is None or self._input.mode not in ['1', 'L']:

--- a/src/mortar/pipeline/filter.py
+++ b/src/mortar/pipeline/filter.py
@@ -45,8 +45,8 @@ class Filter:
 
     @override
     def __eq__(self: object, other: object) -> bool:
-        self_attrs = []
-        other_attrs = []
+        self_attrs: list[Any] = []
+        other_attrs: list[Any] = []
 
         for attr, _ in self.__dict__.items():
             self_attrs.append(attr)

--- a/src/mortar/pipeline/filter.py
+++ b/src/mortar/pipeline/filter.py
@@ -1,3 +1,4 @@
+# pyright: reportAny=false,reportExplicitAny=false
 """
 This module provides pipeline filters.
 

--- a/src/mortar/pipeline/filter.py
+++ b/src/mortar/pipeline/filter.py
@@ -12,10 +12,10 @@ from typing import Any, Optional
 import cv2 as cv
 import numpy as np
 from mktech.validate import ensure_type
-from mortar.tesseract import ocr
-from mortar.util import mktemp
 
 from mortar.image import Image
+from mortar.tesseract import ocr
+from mortar.util import mktemp
 
 
 class Filter:

--- a/src/mortar/pipeline/filter.py
+++ b/src/mortar/pipeline/filter.py
@@ -23,12 +23,12 @@ class Filter:
     Base class which any image filter inherits.
     """
 
-    name = 'Filter'
+    name: str = 'Filter'
     " The name of the filter. "
     _input_type: Any = Any
 
     def __init__(self) -> None:
-        self._input = None
+        self._input: Any = None
 
     def info(self) -> str:
         """ Return the name of the filter. """
@@ -80,13 +80,13 @@ class Filter:
 class Crop(Filter):
     """ Crop an image to a specified box. """
 
-    name = 'Crop'
-    _input_type = Image
+    name: str = 'Crop'
+    _input_type: Any = Image
 
     def __init__(self, coords: tuple[int, int, int, int]) -> None:
         super().__init__()
 
-        self._coords = coords
+        self._coords: tuple[int, int, int, int] = coords
 
     @override
     def info(self) -> str:
@@ -114,8 +114,8 @@ class Crop(Filter):
 class Gray(Filter):
     """ Convert an image to 8-bit grayscale mode. """
 
-    name = 'Gray'
-    _input_type = Image
+    name: str = 'Gray'
+    _input_type: Any = Image
 
     @override
     def run(self, input: Image) -> Image | None:
@@ -132,8 +132,8 @@ class Gray(Filter):
 class Invert(Filter):
     """ Invert an image channel. """
 
-    name = 'Invert'
-    _input_type = Image
+    name: str = 'Invert'
+    _input_type: Any = Image
 
     @override
     def run(self, input: Image) -> Image | None:
@@ -150,8 +150,8 @@ class Invert(Filter):
 class OCR(Filter):
     """ Perform OCR on an image. """
 
-    name = 'OCR'
-    _input_type = Image
+    name: str = 'OCR'
+    _input_type: Any = Image
 
     @override
     def run(self, input: Image) -> str | None:
@@ -181,8 +181,8 @@ class Threshold(Filter):
     Must be a grayscale image (image.mode in ['1', 'L'])
     """
 
-    name = 'Threshold'
-    _input_type = Image
+    name: str = 'Threshold'
+    _input_type: Any = Image
 
     def __init__(
         self,
@@ -192,9 +192,9 @@ class Threshold(Filter):
     ) -> None:
         super().__init__()
 
-        self.threshval = threshval
-        self.maxval = maxval
-        self.invert = invert
+        self.threshval: float = threshval
+        self.maxval: float = maxval
+        self.invert: bool = invert
 
     @override
     def run(self, input: Image) -> Image | None:

--- a/src/mortar/process.py
+++ b/src/mortar/process.py
@@ -4,7 +4,7 @@ This module provides facilities for executing operating system processes.
 
 import subprocess
 from subprocess import CalledProcessError, CompletedProcess
-from typing import Any
+from typing import Any, cast
 
 from mktech import log
 
@@ -27,7 +27,7 @@ def run(*args: Any, **kwargs: Any) -> CompletedProcess[bytes]:
     log.info(f'run {args}')
 
     try:
-        result = subprocess.run(
+        result: CompletedProcess[bytes] = subprocess.run(  # pyright: ignore[reportUnknownVariableType] # noqa: E501
             *args, capture_output=True, check=True, **kwargs
         )
     except CalledProcessError as e:
@@ -36,7 +36,7 @@ def run(*args: Any, **kwargs: Any) -> CompletedProcess[bytes]:
 
         raise e
 
-    log.info(f'stdout={result.stdout}')
-    log.info(f'stderr={result.stderr}')
+    log.info(f'stdout={cast(str, result.stdout)}')
+    log.info(f'stderr={cast(str, result.stderr)}')
 
-    return result
+    return result  # pyright: ignore[reportUnknownVariableType]

--- a/src/mortar/process.py
+++ b/src/mortar/process.py
@@ -11,7 +11,10 @@ from mktech import log
 __all__ = ['CompletedProcess', 'run']
 
 
-def run(*args: Any, **kwargs: Any) -> CompletedProcess[bytes]:
+def run(
+    *args: Any,  # pyright: ignore[reportAny,reportExplicitAny]
+    **kwargs: Any,  # pyright: ignore[reportAny,reportExplicitAny]
+) -> CompletedProcess[bytes]:
     """
     Run the command described by args in a child process. args is a sequence
     representing the command name and its space-separated arguments.
@@ -28,11 +31,11 @@ def run(*args: Any, **kwargs: Any) -> CompletedProcess[bytes]:
 
     try:
         result: CompletedProcess[bytes] = subprocess.run(  # pyright: ignore[reportUnknownVariableType] # noqa: E501
-            *args, capture_output=True, check=True, **kwargs
+            *args, capture_output=True, check=True, **kwargs  # pyright: ignore[reportAny] # noqa: E501
         )
     except CalledProcessError as e:
-        log.error(f'stdout={e.stdout}')
-        log.error(f'stderr={e.stderr}')
+        log.error(f'stdout={e.stdout}')  # pyright: ignore[reportAny]
+        log.error(f'stderr={e.stderr}')  # pyright: ignore[reportAny]
 
         raise e
 

--- a/src/mortar/shell.py
+++ b/src/mortar/shell.py
@@ -2,7 +2,12 @@
 This module provides an interactive shell interface to the mortar package.
 """
 
+from typing import cast
+
 import IPython
+from IPython.core.shellapp import InteractiveShellApp
+from IPython.terminal.interactiveshell import TerminalInteractiveShell
+from IPython.terminal.ipapp import TerminalIPythonApp
 from traitlets.config import Config
 
 
@@ -11,21 +16,28 @@ def run(file: str | None) -> int:
 
     # On startup, make mortar facilities available in the IPython shell.
 
-    c.InteractiveShellApp.exec_lines = [
+    interactive_shell_app = cast(InteractiveShellApp, c.InteractiveShellApp)
+
+    terminal_ipython_app = cast(TerminalIPythonApp, c.TerminalIPythonApp)
+
+    interactive_shell_app.exec_lines = [
         'from mortar.pipeline import *',
         'print("mortar command line interface")'
     ]
 
-    c.InteractiveShell.confirm_exit = False
-    c.TerminalIPythonApp.display_banner = False
+    interactive_shell = cast(TerminalInteractiveShell, c.InteractiveShell)
+
+    interactive_shell.confirm_exit = False
+
+    terminal_ipython_app.display_banner = False
 
     # If a script argument was provided, run it. Remain in the shell after the
     # script has completed.
 
     if file is not None:
-        c.InteractiveShellApp.file_to_run = file
+        interactive_shell_app.file_to_run = file
 
-    c.TerminalIPythonApp.force_interact = True
+    terminal_ipython_app.force_interact = True
 
     IPython.start_ipython(  # type: ignore[no-untyped-call] # pyright: ignore[reportUnknownMemberType] # noqa: E501
         config=c, argv=[]

--- a/src/mortar/shell.py
+++ b/src/mortar/shell.py
@@ -27,6 +27,8 @@ def run(file: str | None) -> int:
 
     c.TerminalIPythonApp.force_interact = True
 
-    IPython.start_ipython(config=c, argv=[])  # type: ignore[no-untyped-call]
+    IPython.start_ipython(  # type: ignore[no-untyped-call] # pyright: ignore[reportUnknownMemberType] # noqa: E501
+        config=c, argv=[]
+    )
 
     return 0

--- a/src/mortar/ssh.py
+++ b/src/mortar/ssh.py
@@ -6,7 +6,6 @@ scp is supported, as is executing arbitrary commands over SSH.
 """
 
 from enum import Enum, auto
-from typing import Optional
 
 from mortar import process
 from mortar.process import CompletedProcess
@@ -24,7 +23,7 @@ class Command(Enum):
 class SSH:
     """ Execute SSH operations between the local host and a remote host. """
     def __init__(
-        self, host: Optional[str] = None, port: Optional[int] = None
+        self, host: str | None = None, port: int | None = None
     ) -> None:
         self.host = host
         " Remote host name "
@@ -70,7 +69,7 @@ class SSH:
         return process.run(ssh_command)
 
     @staticmethod
-    def _build_args(command: Command, port: Optional[int]) -> list[str]:
+    def _build_args(command: Command, port: int | None) -> list[str]:
         args = []
 
         if port is not None:

--- a/src/mortar/ssh.py
+++ b/src/mortar/ssh.py
@@ -70,7 +70,7 @@ class SSH:
 
     @staticmethod
     def _build_args(command: Command, port: int | None) -> list[str]:
-        args = []
+        args: list[str] = []
 
         if port is not None:
             if command == Command.SSH:

--- a/src/mortar/ssh.py
+++ b/src/mortar/ssh.py
@@ -25,9 +25,9 @@ class SSH:
     def __init__(
         self, host: str | None = None, port: int | None = None
     ) -> None:
-        self.host = host
+        self.host: str | None = host
         " Remote host name "
-        self.port = port
+        self.port: int | None = port
         " Remote host port "
 
     def scp_to(self, local: str, remote: str) -> CompletedProcess[bytes]:

--- a/src/mortar/ssh.py
+++ b/src/mortar/ssh.py
@@ -8,9 +8,8 @@ scp is supported, as is executing arbitrary commands over SSH.
 from enum import Enum, auto
 from typing import Optional
 
-from mortar.process import CompletedProcess
-
 from mortar import process
+from mortar.process import CompletedProcess
 
 
 class Command(Enum):

--- a/src/mortar/ssh.py
+++ b/src/mortar/ssh.py
@@ -77,8 +77,6 @@ class SSH:
                 args.append('-p')
             elif command == Command.SCP:
                 args.append('-P')
-            else:
-                raise Exception()
 
             args.append(str(port))
 

--- a/src/mortar/tesseract.py
+++ b/src/mortar/tesseract.py
@@ -47,13 +47,13 @@ def tesseract_ssh(path_: str) -> str:
     temp_win = "C:/Windows/Temp"
     temp_nix = '/mnt/c/Windows/Temp'
 
-    ssh.scp_to(str(path), f'{temp_nix}/{path.name}')
-    ssh.run([tess_cmd + f' "{temp_win}\\{path.name}" "{temp_win}\\out"'])
+    _ = ssh.scp_to(str(path), f'{temp_nix}/{path.name}')
+    _ = ssh.run([tess_cmd + f' "{temp_win}\\{path.name}" "{temp_win}\\out"'])
 
     (_, out_path) = mkstemp()
 
-    ssh.scp_from(f'{temp_nix}/out.txt', out_path)
-    ssh.run(['rm', f'{temp_nix}/{path.name}'])
+    _ = ssh.scp_from(f'{temp_nix}/out.txt', out_path)
+    _ = ssh.run(['rm', f'{temp_nix}/{path.name}'])
 
     with open(out_path, 'r') as fi:
         result = fi.read()
@@ -76,7 +76,7 @@ def tesseract_wsl(path_: str) -> str:
     out_stem = 'out'
     out_name = f'{out_stem}.txt'
 
-    process.run(_tess_cmd + [path, out_stem])
+    _ = process.run(_tess_cmd + [path, out_stem])
 
     with open(out_name, 'r') as fi:
         result = fi.read()

--- a/src/mortar/util.py
+++ b/src/mortar/util.py
@@ -5,6 +5,7 @@ other existing modules.
 
 import platform
 import time
+from os import PathLike
 from os.path import isfile
 from tempfile import mkstemp
 from typing import Any
@@ -25,7 +26,12 @@ def system() -> str:
         return platform.system()
 
 
-def mktemp(*args: Any, **kwargs: Any) -> str:
+def mktemp(
+    suffix: str | None = None,
+    prefix: str | None = None,
+    dir: str | PathLike[str] | None = None,
+    **kwargs: Any
+) -> str:
     """
     Make a temporary file, taking the host system into account.
 
@@ -39,15 +45,13 @@ def mktemp(*args: Any, **kwargs: Any) -> str:
     if system() == 'wsl':
         now = time.time()
 
-        if 'suffix' not in kwargs:
+        if suffix is None:
             suffix = ''
-        else:
-            suffix = kwargs['suffix']
 
         output_path = f'{_windows_temp}/{now}{suffix}'
 
         _ = open(output_path, 'w')
     else:
-        (_, output_path) = mkstemp(*args, **kwargs)
+        _, output_path = mkstemp(suffix, prefix, dir, **kwargs)
 
     return output_path

--- a/src/mortar/util.py
+++ b/src/mortar/util.py
@@ -30,7 +30,7 @@ def mktemp(
     suffix: str | None = None,
     prefix: str | None = None,
     dir: str | PathLike[str] | None = None,
-    **kwargs: Any
+    **kwargs: Any  # pyright: ignore[reportAny,reportExplicitAny]
 ) -> str:
     """
     Make a temporary file, taking the host system into account.
@@ -52,6 +52,6 @@ def mktemp(
 
         _ = open(output_path, 'w')
     else:
-        _, output_path = mkstemp(suffix, prefix, dir, **kwargs)
+        _, output_path = mkstemp(suffix, prefix, dir, **kwargs)  # pyright: ignore[reportAny] # noqa: E501
 
     return output_path

--- a/src/mortar/util.py
+++ b/src/mortar/util.py
@@ -46,7 +46,7 @@ def mktemp(*args: Any, **kwargs: Any) -> str:
 
         output_path = f'{_windows_temp}/{now}{suffix}'
 
-        open(output_path, 'w')
+        _ = open(output_path, 'w')
     else:
         (_, output_path) = mkstemp(*args, **kwargs)
 

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -9,7 +9,7 @@ from mortar.image import Detector
 data = f'{os.getcwd()}/tests/data/detector'
 
 
-def iog_jp_charity_detector_fn(x: int, y: int, w: int, h: int) -> bool:
+def iog_jp_charity_detector_fn(x: int, _y: int, w: int, h: int) -> bool:
     if (x == 880):
         return h > 100 and w < 700
     return h > 200 and w < 1083

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -35,7 +35,7 @@ class TestFilter:
 
         output = ensure_type(threshold.run(image), Image)
 
-        out_data = list(output.getdata())
+        out_data = list(output.getdata())  # pyright: ignore[reportAny]
 
         top_pixel_count = int(pixel_count / 2) + 50
         top = out_data[0:top_pixel_count]

--- a/tests/test_mort.py
+++ b/tests/test_mort.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+
 from mortar.tesseract import ocr
 
 data = f'{os.getcwd()}/tests/data/mort'

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,7 +1,7 @@
 import os
+from collections.abc import Sequence
 from shutil import rmtree
 from tempfile import mkdtemp
-from typing import Sequence
 
 from mktech.validate import ensure_type
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -161,8 +161,8 @@ def test_pipeline_modify() -> None:
 
     # Remove stages, run modified pipeline, and check.
 
-    pipeline.pop(2)
-    pipeline.pop(0)
+    _ = pipeline.pop(2)
+    _ = pipeline.pop(0)
 
     output = pipeline.run(image)
 
@@ -277,7 +277,7 @@ def test_pipeline_copy() -> None:
     # Modify the original pipeline. Ensure that the copy is not affected when
     # the original is modified.
 
-    pipeline.pop(0)
+    _ = pipeline.pop(0)
     pipeline.name = 'Pipeline original with crop mod'
     pipeline.insert(0, Crop(top_right))
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -61,9 +61,9 @@ def test_pipeline() -> None:
     output = pipeline.run(image)
 
     stages = output.stages
-    i1 = ensure_type(stages[1].data, Image)
-    i2 = ensure_type(stages[2].data, Image)
-    i3 = ensure_type(stages[3].data, Image)
+    i1 = ensure_type(stages[1].data, Image)  # pyright: ignore[reportAny]
+    i2 = ensure_type(stages[2].data, Image)  # pyright: ignore[reportAny]
+    i3 = ensure_type(stages[3].data, Image)  # pyright: ignore[reportAny]
 
     if _debug:
         temp = mkdtemp(prefix='test_pipeline')
@@ -91,7 +91,7 @@ def test_pipeline_ocr() -> None:
     output = pipeline.run(image)
 
     stages = output.stages
-    s3 = ensure_type(stages[3].data, str)
+    s3 = ensure_type(stages[3].data, str)  # pyright: ignore[reportAny]
 
     assert s3 == '''ご ぞ ど ば ぼ ば ぼ ま
 げ ゼ ぜ ゼ ぜ で べ ペ


### PR DESCRIPTION
Replace mypy with basedpyright as the primary type checker.

- Add `pyrightconfig.json`
- Fix type errors found by basedpyright
- Make changes around type annotations to satisfy basedpyright default settings so there are no type warnings (these are stricter than mypy's in some ways)
- Disable the pylsp-mypy plugin for pylsp
- Run basedpyright in the nox typing session